### PR TITLE
Fix vlogin and vdo messages

### DIFF
--- a/modules/xonotic/handler/log.hpp
+++ b/modules/xonotic/handler/log.hpp
@@ -313,7 +313,7 @@ public:
     ShowVoteLogin(const Settings& settings, MessageConsumer* parent)
     : ParseEventlog(R"(^:vote:vlogin:(\d+))", settings, parent)
     {
-        message = settings.get("message",
+        message = read_string(settings, "message",
             "$(4)*$(-) $name$(-) logged in as $(dark_yellow)master");
     }
 
@@ -339,7 +339,7 @@ public:
     ShowVoteDo(const Settings& settings, MessageConsumer* parent)
     : ParseEventlog(R"(^:vote:vdo:(\d+):(.*))", settings, parent)
     {
-        message = settings.get("message",
+        message = read_string(settings, "message",
             "$(4)*$(-) $name$(-) used their master status to do $vote");
     }
 


### PR DESCRIPTION
Without those changes `vlogin` and `vdo` looks like that:

    14:53 <+reg> pub $(4)*$(-) $name$(-) logged in as $(dark_yellow)master
    14:53 <+reg> pub $(4)*$(-) $name$(-) used their master status to do $vote
    14:53 <+reg> pub $(4)*$(-) $name$(-) used their master status to do $vote

